### PR TITLE
Merge `git push --all` and `git push --prune` steps

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ case "${GITHUB_EVENT_NAME}" in
 push|create|pull_request|workflow_dispatch)
   git-setup
   git fetch --all
-  git push -f ${INPUT_CISKIP:+-o ci.skip} --all --prune ${INPUT_REMOTE}
+  git push -f ${INPUT_CISKIP:+-o ci.skip} --mirror ${INPUT_REMOTE}
   git push -f --tags ${INPUT_REMOTE}
     ;;
 delete)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,8 +17,7 @@ case "${GITHUB_EVENT_NAME}" in
 push|create|pull_request|workflow_dispatch)
   git-setup
   git fetch --all
-  git push -f ${INPUT_CISKIP:+-o ci.skip} --all ${INPUT_REMOTE}
-  git push -f --prune ${INPUT_REMOTE}
+  git push -f ${INPUT_CISKIP:+-o ci.skip} --all --prune ${INPUT_REMOTE}
   git push -f --tags ${INPUT_REMOTE}
     ;;
 delete)


### PR DESCRIPTION
`git push --prune` tries to use default push configuration, which doesn't work when HEAD is not on a branch. One fix could be to specify refs that prune is supposed to push, but we already have a push for `--all`, so why not combine the operations.

This is intended as a fix for failed tag sync such as one in https://github.com/eic/containers/actions/runs/20833337476/job/59852664256