### PR TITLE
Fix prune push failing on tag triggers (detached HEAD)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ push|create|pull_request|workflow_dispatch)
   git-setup
   git fetch --all
   git push -f ${INPUT_CISKIP:+-o ci.skip} --all ${INPUT_REMOTE}
-  git push -f --prune ${INPUT_REMOTE}
+  git push -f --prune ${INPUT_REMOTE} "refs/remotes/origin/*:refs/heads/*"
   git push -f --tags ${INPUT_REMOTE}
     ;;
 delete)


### PR DESCRIPTION
When the workflow is triggered by a tag, the repo is in a detached HEAD state, causing 'git push -f --prune' to fail with:
  fatal: You are not currently on a branch.

Pass an explicit refspec (refs/remotes/origin/*:refs/heads/*) so --prune no longer depends on the current branch and mirrors all origin branches to the target.

Closes: #3 