### PR TITLE
Push from local refs/heads/* instead of refs/remotes/origin/*

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,8 +17,14 @@ case "${GITHUB_EVENT_NAME}" in
 push|create|pull_request|workflow_dispatch)
   git-setup
   git fetch --all
+  # Recreate local branches from origin/* so --prune has a stable source side
+  # (GitHub Actions checkout is normally detached HEAD, and origin/HEAD is
+  # not a valid branch name on the target).
+  git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin/ \
+    | grep -vE '^HEAD$' \
+    | while read -r b; do git branch -f "$b" "refs/remotes/origin/$b"; done
   git push -f ${INPUT_CISKIP:+-o ci.skip} --all ${INPUT_REMOTE}
-  git push -f --prune ${INPUT_REMOTE} "refs/remotes/origin/*:refs/heads/*"
+  git push -f --prune ${INPUT_REMOTE} "refs/heads/*:refs/heads/*"
   git push -f --tags ${INPUT_REMOTE}
     ;;
 delete)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,9 @@ case "${GITHUB_EVENT_NAME}" in
 push|create|pull_request|workflow_dispatch)
   git-setup
   git fetch --all
+  # Detach HEAD so that git branch -f can update every branch (including the
+  # one currently checked out by the Actions runner).
+  git checkout --detach HEAD
   # Recreate local branches from origin/* so --prune has a stable source side
   # (GitHub Actions checkout is normally detached HEAD, and origin/HEAD is
   # not a valid branch name on the target).


### PR DESCRIPTION
The previous fix passed 'refs/remotes/origin/*:refs/heads/*' to 'git push --prune'. That also tried to push refs/remotes/origin/HEAD as a branch literally named 'HEAD' on the target, which GitLab rejects with:

  remote: GitLab: You cannot create a branch with an invalid name.

Because the push is atomic, that single bad ref caused every other branch in the same push to be rejected with 'pre-receive hook declined'.

Instead, recreate local branches from origin/* (excluding HEAD) and push 'refs/heads/*:refs/heads/*'. This keeps --prune working without depending on the current branch (still safe under detached HEAD on tag triggers) and avoids the invalid 'HEAD' ref.

### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

### What is the urgency of this PR?
- [ ] High (please describe reason below)
- [x] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.
